### PR TITLE
Configure GCC defaults to tune for atom

### DIFF
--- a/initial_bootstrap/Dockerfile
+++ b/initial_bootstrap/Dockerfile
@@ -30,6 +30,7 @@ USER user
 RUN cat /proc/cpuinfo && cat /proc/meminfo && df -h
 
 RUN wget https://gitweb.gentoo.org/repo/proj/prefix.git/plain/scripts/bootstrap-prefix.sh && chmod +x bootstrap-prefix.sh
+RUN sed -i "s/EXTRA_ECONF=\"/EXTRA_ECONF=\"--with-mtune=atom\ /;s/--host/--with-mtune=atom --host/;3iexport EXTRA_ECONF=\"--with-tune=atom\"" bootstrap-prefix.sh
 ENV EPREFIX /tmp/gentoo
 
 # Bootstrap Gentoo Prefix


### PR DESCRIPTION
This option avoids the additional instructions that get introduced by tune=generic on i686, but aren't available on atom.
This option is consistent with other distributions (e.g., https://fedoraproject.org/wiki/Features/F12X86Support).

Hi Sam,

I believe that this will avoid the problem with getting invalid instructions when running on atom processors.
